### PR TITLE
Toggle plot titles via config

### DIFF
--- a/AppConfig.h
+++ b/AppConfig.h
@@ -27,6 +27,9 @@ struct AppConfig {
     // signal val to uW conversion - double check this conversion
     static inline double adcOffset = 49555.0;
     static inline double adcToMicroWatts   = 0.0147;
+
+    // Show plot titles like "Frequency Domain" and "Time Domain"
+    static inline bool showPlotTitles = false;
 };
 
 #endif // APPCONFIG_H

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -25,9 +25,10 @@
 // Determine maximum x-axis limit based on plot type
 static double getMaxXAxisLimit(QwtPlot *plot)
 {
-    if (plot->title().text() == "Frequency Domain")
+    const QString name = plot->objectName();
+    if (name == "FFT_plot")
         return (AppConfig::sampleRate >= 1e6) ? 40.0 : 100; // MHz or kHz
-    if (plot->title().text() == "Time Domain")
+    if (name == "Time_plot")
         return AppConfig::timeWindowSeconds * 1e6;          // microseconds
     return 1e9;                         // fallback large limit
 }
@@ -142,15 +143,19 @@ PlotManager::PlotManager(QwtPlot *fftPlot, QwtPlot *timePlot, QObject *parent)
     fftPlot_->setCanvasBackground(backgroundColor);
     timePlot_->setCanvasBackground(backgroundColor);
 
-    {
+    if (AppConfig::showPlotTitles) {
         QwtText t("Frequency Domain");
         t.setColor(lightGray);
         fftPlot_->setTitle(t);
+    } else {
+        fftPlot_->setTitle("");
     }
-    {
+    if (AppConfig::showPlotTitles) {
         QwtText t("Time Domain");
         t.setColor(lightGray);
         timePlot_->setTitle(t);
+    } else {
+        timePlot_->setTitle("");
     }
 
     {


### PR DESCRIPTION
## Summary
- support optional titles on FFT and time plots
- determine max x-axis limit by plot object name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c7fbf7d883288470ac67d7552dfd